### PR TITLE
Reorder slides to make demo flow better

### DIFF
--- a/talk.md
+++ b/talk.md
@@ -251,37 +251,6 @@ Gain this through the frameworks creating _computational directed acyclic graphs
    - Get data (observations + auxiliary measurements)
 
 ---
-# JSON Patch for new signal models
-<!--  -->
-.kol-1-2[
-<br>
-.center.width-90[![demo_JSON](figures/carbon_JSON_spec_short.png)]
-.center[Original model]
-]
-.kol-1-2[
-<!-- <br> -->
-.center.width-90[![patch_file](figures/carbon_patch.png)]
-.center[New Signal (JSON Patch file)]
-]
-.kol-1-1[
-.center.width-60[![demo_JSON](figures/carbon_patched_JSON.png)]
-.center[Reinterpretation]
-]
-
----
-# JSON Patch for new signal models
-<!--  -->
-.center.width-60[![signal_reinterpretation](figures/carbon_reinterpretation.png)]
-.kol-1-2[
-.center.width-50[![measurement_cartoon](figures/measurement_cartoon.png)]
-.center[Original analysis (model A)]
-]
-.kol-1-2[
-.center.width-50[![reinterpretation_cartoon](figures/reinterpretation_cartoon.png)]
-.center[Recast analysis (model B)]
-]
-
----
 # Interval estimation
 
 .kol-1-2[
@@ -338,6 +307,38 @@ Gain this through the frameworks creating _computational directed acyclic graphs
 - Not yet, but there is a PR to add this functionality into the CLI
    - [scikit-hep/pyhf PR #617](https://github.com/scikit-hep/pyhf/pull/617)
 - `$ pyhf spec combine spec1.json spec2.json`
+
+---
+# JSON Patch for new signal models
+<!--  -->
+.kol-1-2[
+<br>
+.center.width-90[![demo_JSON](figures/carbon_JSON_spec_short.png)]
+.center[Original model]
+]
+.kol-1-2[
+<!-- <br> -->
+.center.width-90[![patch_file](figures/carbon_patch.png)]
+.center[New Signal (JSON Patch file)]
+]
+.kol-1-1[
+.center.width-60[![demo_JSON](figures/carbon_patched_JSON.png)]
+.center[Reinterpretation]
+]
+
+---
+# JSON Patch for new signal models
+<!--  -->
+.center.width-60[![signal_reinterpretation](figures/carbon_reinterpretation.png)]
+.kol-1-2[
+.center.width-50[![measurement_cartoon](figures/measurement_cartoon.png)]
+.center[Original analysis (model A)]
+]
+.kol-1-2[
+.center.width-50[![reinterpretation_cartoon](figures/reinterpretation_cartoon.png)]
+.center[Recast analysis (model B)]
+]
+
 
 ---
 # Likelihoods preserved on HEPData


### PR DESCRIPTION
Have interval estimation slides come up while showing the code in the demo